### PR TITLE
Downgrade dispatch-json4s-native to 0.11.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ scalacOptions in ThisBuild ++= Seq(Opts.compile.deprecation) ++
   Seq("-Ywarn-unused-import", "-Ywarn-unused", "-Xlint", "-feature").filter(
     Function.const(scalaVersion.value.startsWith("2.11")))
 
-libraryDependencies ++= Seq("net.databinder.dispatch" %% "dispatch-json4s-native" % "0.11.3")
+libraryDependencies ++= Seq("net.databinder.dispatch" %% "dispatch-json4s-native" % "0.11.2")
 
 initialCommands := "import scala.concurrent.ExecutionContext.Implicits.global;"
 


### PR DESCRIPTION
`dispatch-json4s-native:0.11.3` depends on json4s:3.2.11 which is incompatible with json4s:3.2.10 used by SBT. See https://github.com/json4s/json4s/issues/212.

Reverts #15