### PR TITLE
Downgrading dependency to solve issue with conflicting json4s-core versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.idea

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ lazy val dispatchVersion = SettingKey[String]("dispatchVersion")
 lazy val unusedWarnings = Seq("-Ywarn-unused-import", "-Ywarn-unused")
 
 lazy val commonSettings: Seq[Setting[_]] = Seq(
-    version in ThisBuild := "0.5.0-SNAPSHOT",
+    version in ThisBuild := "0.6.0",
     organization in ThisBuild := "org.foundweekends",
     homepage in ThisBuild := Some(url(s"https://github.com/sbt/${name.value}/#readme")),
     licenses in ThisBuild := Seq("MIT" ->
@@ -38,10 +38,13 @@ lazy val root = (project in file("."))
     description := "your packages, delivered fresh",
     dispatchVersion := {
       CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, 10)) => "0.11.3"
+        case Some((2, 10)) => "0.11.2"
         case _             => "0.12.0"
       }
     },
-    libraryDependencies ++= Seq("net.databinder.dispatch" %% "dispatch-json4s-native" % dispatchVersion.value),
+    libraryDependencies ++= Seq(
+      "net.databinder.dispatch" %% "dispatch-json4s-native" % dispatchVersion.value,
+      "org.scalatest" %% "scalatest" % "3.0.0" % "test"
+    ),
     initialCommands := "import scala.concurrent.ExecutionContext.Implicits.global;"
   )

--- a/src/test/scala/JsonVersionLibSpec.scala
+++ b/src/test/scala/JsonVersionLibSpec.scala
@@ -1,0 +1,56 @@
+import org.json4s.JsonDSL._
+import org.json4s.native.JsonMethods
+import org.scalatest.{MustMatchers, WordSpec}
+
+class JsonVersionLibSpec extends WordSpec with MustMatchers {
+
+  val jsonMethods = new JsonMethods {}
+
+  "Stringifying json" should {
+    println(s"Scala version tested is: ${scala.util.Properties.versionString}")
+
+    "should work all values" in {
+
+      val rendered = jsonMethods.compact(
+        jsonMethods.render(
+          ("name"     -> "randomName") ~
+          ("desc"     -> Option("basicDescription")) ~
+          ("licenses" -> List("Apache", "MIT")) ~
+          ("labels"   -> List("label1", "label2")) ~
+          ("vcs_url"  -> Option("vcs"))
+        )
+      )
+
+      rendered must be(
+        "{" +
+          """"name":"randomName",""" +
+          """"desc":"basicDescription",""" +
+          """"licenses":["Apache","MIT"],""" +
+          """"labels":["label1","label2"],""" +
+          """"vcs_url":"vcs"""" +
+        "}"
+      )
+    }
+
+    "should work with some values omitted" in {
+
+      val rendered = jsonMethods.compact(
+        jsonMethods.render(
+          ("name"     -> "randomName") ~
+            ("desc"     -> (None : Option[String])) ~
+            ("licenses" -> List[String]()) ~
+            ("labels"   -> List[String]()) ~
+            ("vcs_url"  -> (None : Option[String]))
+        )
+      )
+
+      rendered must be(
+        "{" +
+          """"name":"randomName",""" +
+          """"licenses":[],""" +
+          """"labels":[]""" +
+          "}"
+      )
+    }
+  }
+}


### PR DESCRIPTION
Issue is described here: https://github.com/sbt/sbt-bintray/issues/104

Although I have actually added unit test I am admitting honestly that it doesn't really reproduce the issue. There is a conflict between two jar versions `json4s-core_2.10-3.2.10.jar` vs `json4s-core_2.10-3.2.11.jar`. It seems that version 3.2.11 lost method: `emptyValueStrategy` which is attempted to being used by `json4s-native` like here:

```
java.lang.NoSuchMethodError: org.json4s.Formats.emptyValueStrategy()Lorg/json4s/prefs/EmptyValueStrategy;
        at org.json4s.native.JsonMethods$class.render(JsonMethods.scala:29)
        at org.json4s.native.JsonMethods$.render(JsonMethods.scala:62)
        at bintry.Methods$json$.str(Methods.scala:19)
        at bintry.Methods$Repo$Package$Version$Attrs$.update(Methods.scala:147)
        at bintray.BintrayRepo$$anonfun$publishVersionAttributes$1.apply(BintrayRepo.scala:23)
        at bintray.BintrayRepo$$anonfun$publishVersionAttributes$1.apply(BintrayRepo.scala:23)
        at bintray.Bintray$await$.ready(Bintray.scala:119)
        at bintray.BintrayRepo.publishVersionAttributes(BintrayRepo.scala:22)
        at bintray.BintrayPlugin$$anonfun$publishVersionAttributesTask$1.apply(BintrayPlugin.scala:149)
        at bintray.BintrayPlugin$$anonfun$publishVersionAttributesTask$1.apply(BintrayPlugin.scala:147)
        at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
        at sbt.$tilde$greater$$anonfun$$u2219$1.apply(TypeFunctions.scala:40)
        at sbt.std.Transform$$anon$4.work(System.scala:63)
        at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
        at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:228)
        at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
        at sbt.Execute.work(Execute.scala:237)
        at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
        at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:228)
        at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
```

The problem with reproducing is that `sbt` itself downloads `json4s-core` whatever you do (if you create empty build.sbt with bare minimum it will pull `json4s-core_2.10-3.2.10.jar `. Therefore I wasn't able to reproduce it in unit testing - i think that it always works `accidentally` - by picking wrong jar version:

```
[pdolega@maracuja jars]$ pwd
/home/pdolega/.ivy2/cache/org.json4s/json4s-core_2.10/jars
[pdolega@maracuja jars]$ ls
json4s-core_2.10-3.2.10.jar  json4s-core_2.10-3.2.11.jar
```

The most important part is - that this fixes the issue here mentioned here: https://github.com/sbt/sbt-bintray/issues/104 (and all related problems in other projects: https://github.com/EmilDafinov/scala-ad-sdk/commit/3ccbcda19c4f10ce23a596d32f2f30fcad2a45ce or https://github.com/RMSone/slick-cats/pull/26 )