### PR TITLE
Fix closing maven central staging repo request to allow skipping closing

### DIFF
--- a/src/main/scala/Methods.scala
+++ b/src/main/scala/Methods.scala
@@ -210,7 +210,7 @@ trait Methods { self: Requests =>
               << json.str(
                 ("username" -> sonatypeUser) ~
                 ("password" -> sonatypePassword) ~
-                ("close"    -> Some("1").filter(Function.const(close)))))
+                ("close"    -> (if (close) "1" else "0"))))
 
         /** https://bintray.com/docs/api/#_delete_version */
         def delete =


### PR DESCRIPTION
I haven't tested if this is a bug, but it seems like one.
As stated in bintray api documentation [here](https://bintray.com/docs/api/#_sync_version_artifacts_to_maven_central),

> By default the staging repository is closed and artifacts are released to Maven Central. You can optionally turn this behaviour off and release the version manually. This is achieved by passing 0 in the 'close' field of the JSON passed to the call.

So it seems that in order to close the repo we need to pass "1" or nothing, and to leave it open, we should pass "0" explicitly. Currently, the code seems to pass "1" if method is called with `close = true`, and pass `null` (?) if method is called with `close = false`. Which would mean it will be closed regardless of what is passed.
I changed the code to be explicit about the close and always send either "1" or "0".

So please correct me if this is wrong. If this is correct, I would like to ask for a possibly quick merge and release. After this I am planning to update sbt-bintray plugin to expose this closing via a setting.
Thanks.
